### PR TITLE
Verifying auto variable available before setting it.

### DIFF
--- a/pyicic/IC_Property.py
+++ b/pyicic/IC_Property.py
@@ -75,8 +75,9 @@ class IC_Property(object):
         """
         """
         
-        # turn off auto first
-        self.auto = False
+        if self.auto_available:
+            # turn off auto first
+            self.auto = False
         
         # set value
         err = self._set_value_funcs[self._prop_type](self._handle,


### PR DESCRIPTION
When trying to set the brightness setting of the camera I got an exception. I noticed that it must happen because we try to set the automatic value of the variable without it even having any.