### PR TITLE
Fix bug in is_camera_property_auto_available

### DIFF
--- a/pyicic/IC_GrabberDLL.py
+++ b/pyicic/IC_GrabberDLL.py
@@ -368,8 +368,8 @@ class IC_GrabberDLL(object):
     #int AC IC_IsCameraPropertyAutoAvailable( HGRABBER hGrabber, CAMERA_PROPERTY iProperty ); ///<Check whether automation for a camera property is available.
     is_camera_property_auto_available = _ic_grabber_dll.IC_IsCameraPropertyAutoAvailable
     is_camera_property_auto_available.restype = c_int
-    is_camera_property_auto_available.argtypes = {GrabberHandlePtr,
-                                                  c_int}
+    is_camera_property_auto_available.argtypes = (GrabberHandlePtr,
+                                                  c_int)
     
     #int AC IC_GetAutoCameraProperty( HGRABBER hGrabber, int iProperty, int *iOnOff ); ///<Retrieve whether automatic is enabled for the specifield camera property.
     get_auto_camera_property = _ic_grabber_dll.IC_GetAutoCameraProperty


### PR DESCRIPTION
Curly braces --> parens

argtypes for is_camera_property_auto_available was improperly a set instead of a tuple.