### PR TITLE
Added remove_overlay().

### DIFF
--- a/pyicic/IC_Camera.py
+++ b/pyicic/IC_Camera.py
@@ -534,3 +534,14 @@ class IC_Camera(object):
                 time.sleep(0.001)
 
         return self._frame['num']
+    
+    def remove_overlay(self, enable):
+        """
+        Enables or disables the overlay. Disable the overlay to capture Y16 images.
+
+        :param enable: 1 to enable the overlay; 0 to disable the overlay.
+
+        :returns: Nothing.
+        """
+        IC_GrabberDLL.remove_overlay(self._handle, enable)
+        return

--- a/pyicic/IC_GrabberDLL.py
+++ b/pyicic/IC_GrabberDLL.py
@@ -652,7 +652,7 @@ class IC_GrabberDLL(object):
     list_video_formats = _ic_grabber_dll.IC_ListVideoFormats
     list_video_formats.restype = c_int
     list_video_formats.argtypes = (GrabberHandlePtr,
-                                   POINTER((c_char * 80) * 40),
+                                   POINTER((c_char * 40) * 80),
                                    c_int)
     
     #//////////////////////////////////////////////////////////////////////////
@@ -1065,7 +1065,11 @@ class IC_GrabberDLL(object):
     #    @param iEnable = 1 inserts overlay, 0 removes the overlay.
     #*/
     #void AC IC_RemoveOverlay( HGRABBER hGrabber, int iEnable );
-    #
+    remove_overlay = _ic_grabber_dll.IC_RemoveOverlay
+    remove_overlay.restype = None
+    enable_trigger.argtypes = (GrabberHandlePtr,
+                               c_int)
+
     #//////////////////////////////////////////////////////////////////////////
     #/*!    Enable or disable the overlay bitmap on the live video
     #    @param hGrabber      Handle to a grabber object.


### PR DESCRIPTION
Added remove_overlay(), maintaining the same style as other functions in IC_Camera.py and IC_GrabberDLL.py. Code is straightforward, and has been tested with the enable parameter set to 0 (to disable the overlay, as required for 16-bit image formats.
No changes to any other parts of these files.
